### PR TITLE
Fix package exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/oleksiikhr/vue-stripe-menu/main/docs/images/stripe.png?raw=true" alt="Vue Stripe Menu" height="500px">
+  <img src="https://raw.githubusercontent.com/oleksiikhr/vue-stripe-menu/main/docs/images/stripe.png?raw=true" alt="Vue Stripe Menu" style="max-height: 500px">
 </p>
 
 > Creating a navigation menu with animations like on Stripe
@@ -45,6 +45,10 @@ createApp({}).use(VueStripeMenu)
 // >>> Install locally - .vue file <<<
 
 import { VsmMenu, VsmMob } from 'vue-stripe-menu'
+
+// Optionally if you don't want to use @import in your
+// <style> section (because its scoped for example):
+// import 'vue-stripe-menu/css'
 
 export default {
   components: {
@@ -103,10 +107,10 @@ Add css/scss styles:
 // https://github.com/oleksiikhr/vue-stripe-menu/blob/main/src/scss/_variables.scss
 // $vsm-transition: .5s;
 
-@import "~vue-stripe-menu/src/scss/index";
+@import "~vue-stripe-menu/scss";
 
 // >>> CSS style <<<
-// @import 'vue-stripe-menu/dist/vue-stripe-menu.css';
+// @import 'vue-stripe-menu/css';
 
 .vsm-menu {
   max-width: 1024px;

--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ createApp({}).use(VueStripeMenu)
 
 import { VsmMenu, VsmMob } from 'vue-stripe-menu'
 
-// Optionally if you don't want to use @import in your
-// <style> section (because its scoped for example):
-// import 'vue-stripe-menu/css'
-
 export default {
   components: {
     VsmMenu, VsmMob
   }
 }
+
+// Optionally if you don't want to use @import in your
+// <style> section (because its scoped for example):
+// import 'vue-stripe-menu/css'
 ```
 
 Add the component:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     ".": {
       "import": "./dist/vue-stripe-menu.es.js",
       "require": "./dist/vue-stripe-menu.umd.js"
-    }
+    },
+    "./css": "./dist/vue-stripe-menu.css",
+    "./scss": "./src/scss/index.scss"
   },
   "unpkg": "./dist/vue-stripe-menu.umd.js",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
       "require": "./dist/vue-stripe-menu.umd.js"
     },
     "./css": "./dist/vue-stripe-menu.css",
-    "./scss": "./src/scss/index.scss"
+    "./scss": "./src/scss/index.scss",
+    "./dist/vue-stripe-menu.css": "./dist/vue-stripe-menu.css",
+    "./src/scss/index": "./src/scss/index.scss"
   },
   "unpkg": "./dist/vue-stripe-menu.umd.js",
   "private": false,


### PR DESCRIPTION
The new exports:

```json
"./css": "./dist/vue-stripe-menu.css",
"./scss": "./src/scss/index.scss"
```

So for <script>:

```javascript
import 'vue-stripe-menu/css'

import 'vue-stripe-menu/scss'
```

or <style>:
```css
@import 'vue-stripe-menu/css';

@import 'vue-stripe-menu/scss';
```
